### PR TITLE
Enhance US-3: username links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,26 @@ This bot allows authorized users to schedule posts to their Telegram channels.
 ## Features
 - User authorization with superadmin.
 - Channel tracking where bot is admin.
-- Schedule message forwarding to channels.
+- Schedule message forwarding to one or more channels with inline interface.
 - View posting history.
+- User lists show clickable usernames for easy profile access.
+
+## User Stories
+
+### Done
+- **US-1**: Registration of the first superadmin.
+- **US-2**: User registration queue with limits and admin approval flow.
+- **US-3**: Superadmin manages pending and approved users. Rejected users cannot
+  register again. Pending and approved lists display clickable usernames with
+  inline approval buttons.
+- **US-4**: Channel listener events and `/channels` command.
+- **US-5**: Post scheduling interface with channel selection, cancellation and rescheduling.
+
+### In Progress
+- **US-6**: Background scheduler to publish messages.
+
+### Planned
+- **US-7**: Logging of all operations.
 
 ## Deployment
 The bot is designed for Fly.io using a webhook on `/webhook` and listens on port `8080`.

--- a/main.py
+++ b/main.py
@@ -16,7 +16,18 @@ WEBHOOK_URL = os.getenv("WEBHOOK_URL", "https://telegram-post-scheduler.fly.dev"
 CREATE_TABLES = [
     """CREATE TABLE IF NOT EXISTS users (
             user_id INTEGER PRIMARY KEY,
+            username TEXT,
             is_superadmin INTEGER DEFAULT 0
+        )""",
+    """CREATE TABLE IF NOT EXISTS pending_users (
+            user_id INTEGER PRIMARY KEY,
+            username TEXT,
+            requested_at TEXT
+        )""",
+    """CREATE TABLE IF NOT EXISTS rejected_users (
+            user_id INTEGER PRIMARY KEY,
+            username TEXT,
+            rejected_at TEXT
         )""",
     """CREATE TABLE IF NOT EXISTS channels (
             chat_id INTEGER PRIMARY KEY,
@@ -41,6 +52,17 @@ class Bot:
         self.db.row_factory = sqlite3.Row
         for stmt in CREATE_TABLES:
             self.db.execute(stmt)
+        self.db.commit()
+        # ensure new columns exist when upgrading
+        for table, column in (
+            ("users", "username"),
+            ("pending_users", "username"),
+            ("rejected_users", "username"),
+        ):
+            cur = self.db.execute(f"PRAGMA table_info({table})")
+            names = [r[1] for r in cur.fetchall()]
+            if column not in names:
+                self.db.execute(f"ALTER TABLE {table} ADD COLUMN {column} TEXT")
         self.db.commit()
         self.pending = {}
         self.session: ClientSession | None = None
@@ -81,10 +103,86 @@ class Bot:
             )
             self.db.commit()
             logging.info("Added channel %s", chat['id'])
+        else:
+            self.db.execute('DELETE FROM channels WHERE chat_id=?', (chat['id'],))
+            self.db.commit()
+            logging.info("Removed channel %s", chat['id'])
 
     def get_user(self, user_id):
         cur = self.db.execute('SELECT * FROM users WHERE user_id=?', (user_id,))
         return cur.fetchone()
+
+    def is_pending(self, user_id: int) -> bool:
+        cur = self.db.execute('SELECT 1 FROM pending_users WHERE user_id=?', (user_id,))
+        return cur.fetchone() is not None
+
+    def pending_count(self) -> int:
+        cur = self.db.execute('SELECT COUNT(*) FROM pending_users')
+        return cur.fetchone()[0]
+
+    def approve_user(self, uid: int) -> bool:
+        if not self.is_pending(uid):
+            return False
+        cur = self.db.execute('SELECT username FROM pending_users WHERE user_id=?', (uid,))
+        row = cur.fetchone()
+        username = row['username'] if row else None
+        self.db.execute('DELETE FROM pending_users WHERE user_id=?', (uid,))
+        self.db.execute('INSERT OR IGNORE INTO users (user_id, username) VALUES (?, ?)', (uid, username))
+        if username:
+            self.db.execute('UPDATE users SET username=? WHERE user_id=?', (username, uid))
+        self.db.execute('DELETE FROM rejected_users WHERE user_id=?', (uid,))
+        self.db.commit()
+        logging.info('Approved user %s', uid)
+        return True
+
+    def reject_user(self, uid: int) -> bool:
+        if not self.is_pending(uid):
+            return False
+        cur = self.db.execute('SELECT username FROM pending_users WHERE user_id=?', (uid,))
+        row = cur.fetchone()
+        username = row['username'] if row else None
+        self.db.execute('DELETE FROM pending_users WHERE user_id=?', (uid,))
+        self.db.execute(
+            'INSERT OR REPLACE INTO rejected_users (user_id, username, rejected_at) VALUES (?, ?, ?)',
+            (uid, username, datetime.utcnow().isoformat()),
+        )
+        self.db.commit()
+        logging.info('Rejected user %s', uid)
+        return True
+
+    def is_rejected(self, user_id: int) -> bool:
+        cur = self.db.execute('SELECT 1 FROM rejected_users WHERE user_id=?', (user_id,))
+        return cur.fetchone() is not None
+
+    def list_scheduled(self):
+        cur = self.db.execute(
+            'SELECT id, target_chat_id, publish_time FROM schedule WHERE sent=0 ORDER BY publish_time'
+        )
+        return cur.fetchall()
+
+    def add_schedule(self, from_chat: int, msg_id: int, targets: set[int], pub_time: str):
+        for chat_id in targets:
+            self.db.execute(
+                'INSERT INTO schedule (from_chat_id, message_id, target_chat_id, publish_time) VALUES (?, ?, ?, ?)',
+                (from_chat, msg_id, chat_id, pub_time),
+            )
+        self.db.commit()
+        logging.info('Scheduled %s -> %s at %s', msg_id, list(targets), pub_time)
+
+    def remove_schedule(self, sid: int):
+        self.db.execute('DELETE FROM schedule WHERE id=?', (sid,))
+        self.db.commit()
+        logging.info('Cancelled schedule %s', sid)
+
+    def update_schedule_time(self, sid: int, pub_time: str):
+        self.db.execute('UPDATE schedule SET publish_time=? WHERE id=?', (pub_time, sid))
+        self.db.commit()
+        logging.info('Rescheduled %s to %s', sid, pub_time)
+
+    @staticmethod
+    def format_user(user_id: int, username: str | None) -> str:
+        label = f"@{username}" if username else str(user_id)
+        return f"[{label}](tg://user?id={user_id})"
 
     def is_authorized(self, user_id):
         return self.get_user(user_id) is not None
@@ -96,28 +194,60 @@ class Bot:
     async def handle_message(self, message):
         text = message.get('text', '')
         user_id = message['from']['id']
+        username = message['from'].get('username')
 
-        # first /start registers superadmin
+        # first /start registers superadmin or puts user in queue
         if text.startswith('/start'):
-            # Previous registration logic preserved for future use:
-            # if not self.get_user(user_id):
-            #     self.db.execute(
-            #         'INSERT INTO users (user_id, is_superadmin) VALUES (?, 1)',
-            #         (user_id,)
-            #     )
-            #     self.db.commit()
-            #     await self.api_request('sendMessage', {
-            #         'chat_id': user_id,
-            #         'text': 'You are superadmin'
-            #     })
-            # else:
-            #     await self.api_request('sendMessage', {
-            #         'chat_id': user_id,
-            #         'text': 'Bot is running'
-            #     })
+            if self.get_user(user_id):
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': 'Bot is working'
+                })
+                return
+
+            if self.is_rejected(user_id):
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': 'Access denied by administrator'
+                })
+                return
+
+            if self.is_pending(user_id):
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': 'Awaiting approval'
+                })
+                return
+
+            cur = self.db.execute('SELECT COUNT(*) FROM users')
+            user_count = cur.fetchone()[0]
+            if user_count == 0:
+                self.db.execute('INSERT INTO users (user_id, username, is_superadmin) VALUES (?, ?, 1)', (user_id, username))
+                self.db.commit()
+                logging.info('Registered %s as superadmin', user_id)
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': 'You are superadmin'
+                })
+                return
+
+            if self.pending_count() >= 10:
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': 'Registration queue full, try later'
+                })
+                logging.info('Registration rejected for %s due to full queue', user_id)
+                return
+
+            self.db.execute(
+                'INSERT OR IGNORE INTO pending_users (user_id, username, requested_at) VALUES (?, ?, ?)',
+                (user_id, username, datetime.utcnow().isoformat())
+            )
+            self.db.commit()
+            logging.info('User %s added to pending queue', user_id)
             await self.api_request('sendMessage', {
                 'chat_id': user_id,
-                'text': 'Bot is working'
+                'text': 'Registration pending approval'
             })
             return
 
@@ -147,13 +277,84 @@ class Bot:
             return
 
         if text.startswith('/list_users') and self.is_superadmin(user_id):
-            cur = self.db.execute('SELECT user_id, is_superadmin FROM users')
+            cur = self.db.execute('SELECT user_id, username, is_superadmin FROM users')
             rows = cur.fetchall()
-            msg = '\n'.join(f"{r['user_id']} {'(admin)' if r['is_superadmin'] else ''}" for r in rows)
-            await self.api_request('sendMessage', {'chat_id': user_id, 'text': msg or 'No users'})
+            msg = '\n'.join(
+                f"{self.format_user(r['user_id'], r['username'])} {'(admin)' if r['is_superadmin'] else ''}"
+                for r in rows
+            )
+            await self.api_request('sendMessage', {
+                'chat_id': user_id,
+                'text': msg or 'No users',
+                'parse_mode': 'Markdown'
+            })
             return
 
-        if text.startswith('/channels'):
+        if text.startswith('/pending') and self.is_superadmin(user_id):
+            cur = self.db.execute('SELECT user_id, username, requested_at FROM pending_users')
+            rows = cur.fetchall()
+            if not rows:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'No pending users'})
+                return
+
+            msg = '\n'.join(
+                f"{self.format_user(r['user_id'], r['username'])} requested {r['requested_at']}"
+                for r in rows
+            )
+            keyboard = {
+                'inline_keyboard': [
+                    [
+                        {'text': 'Approve', 'callback_data': f'approve:{r["user_id"]}'},
+                        {'text': 'Reject', 'callback_data': f'reject:{r["user_id"]}'}
+                    ]
+                    for r in rows
+                ]
+            }
+            await self.api_request('sendMessage', {
+                'chat_id': user_id,
+                'text': msg,
+                'parse_mode': 'Markdown',
+                'reply_markup': keyboard
+            })
+            return
+
+        if text.startswith('/approve') and self.is_superadmin(user_id):
+            parts = text.split()
+            if len(parts) == 2:
+                uid = int(parts[1])
+                if self.approve_user(uid):
+                    cur = self.db.execute('SELECT username FROM users WHERE user_id=?', (uid,))
+                    row = cur.fetchone()
+                    uname = row['username'] if row else None
+                    await self.api_request('sendMessage', {
+                        'chat_id': user_id,
+                        'text': f'{self.format_user(uid, uname)} approved',
+                        'parse_mode': 'Markdown'
+                    })
+                    await self.api_request('sendMessage', {'chat_id': uid, 'text': 'You are approved'})
+                else:
+                    await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'User not in pending list'})
+            return
+
+        if text.startswith('/reject') and self.is_superadmin(user_id):
+            parts = text.split()
+            if len(parts) == 2:
+                uid = int(parts[1])
+                if self.reject_user(uid):
+                    cur = self.db.execute('SELECT username FROM rejected_users WHERE user_id=?', (uid,))
+                    row = cur.fetchone()
+                    uname = row['username'] if row else None
+                    await self.api_request('sendMessage', {
+                        'chat_id': user_id,
+                        'text': f'{self.format_user(uid, uname)} rejected',
+                        'parse_mode': 'Markdown'
+                    })
+                    await self.api_request('sendMessage', {'chat_id': uid, 'text': 'Your registration was rejected'})
+                else:
+                    await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'User not in pending list'})
+            return
+
+        if text.startswith('/channels') and self.is_superadmin(user_id):
             cur = self.db.execute('SELECT chat_id, title FROM channels')
             rows = cur.fetchall()
             msg = '\n'.join(f"{r['title']} ({r['chat_id']})" for r in rows)
@@ -167,6 +368,24 @@ class Bot:
             rows = cur.fetchall()
             msg = '\n'.join(f"{r['target_chat_id']} at {r['sent_at']}" for r in rows)
             await self.api_request('sendMessage', {'chat_id': user_id, 'text': msg or 'No history'})
+            return
+
+        if text.startswith('/scheduled') and self.is_authorized(user_id):
+            rows = self.list_scheduled()
+            if not rows:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'No scheduled posts'})
+                return
+            msg = '\n'.join(f"{r['id']}: {r['target_chat_id']} at {r['publish_time']}" for r in rows)
+            keyboard = {
+                'inline_keyboard': [
+                    [
+                        {'text': 'Cancel', 'callback_data': f'cancel:{r["id"]}'},
+                        {'text': 'Reschedule', 'callback_data': f'resch:{r["id"]}'}
+                    ]
+                    for r in rows
+                ]
+            }
+            await self.api_request('sendMessage', {'chat_id': user_id, 'text': msg, 'reply_markup': keyboard})
             return
 
         # handle time input for scheduling
@@ -192,15 +411,18 @@ class Bot:
                 })
                 return
             data = self.pending.pop(user_id)
-            self.db.execute(
-                'INSERT INTO schedule (from_chat_id, message_id, target_chat_id, publish_time) VALUES (?, ?, ?, ?)',
-                (data['from_chat_id'], data['message_id'], data['target_chat_id'], pub_time.isoformat())
-            )
-            self.db.commit()
-            await self.api_request('sendMessage', {
-                'chat_id': user_id,
-                'text': f'Scheduled for {pub_time}'
-            })
+            if 'reschedule_id' in data:
+                self.update_schedule_time(data['reschedule_id'], pub_time.isoformat())
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': f'Rescheduled for {pub_time}'
+                })
+            else:
+                self.add_schedule(data['from_chat_id'], data['message_id'], data['selected'], pub_time.isoformat())
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': f"Scheduled to {len(data['selected'])} channels for {pub_time}"
+                })
             return
 
         # start scheduling on forwarded message
@@ -216,15 +438,18 @@ class Bot:
                 })
                 return
             keyboard = {
-                'inline_keyboard': [[{'text': r['title'], 'callback_data': f"channel:{r['chat_id']}"}] for r in rows]
+                'inline_keyboard': [
+                    [{'text': r['title'], 'callback_data': f'addch:{r["chat_id"]}'}] for r in rows
+                ] + [[{'text': 'Done', 'callback_data': 'chdone'}]]
             }
             self.pending[user_id] = {
                 'from_chat_id': from_chat,
-                'message_id': msg_id
+                'message_id': msg_id,
+                'selected': set()
             }
             await self.api_request('sendMessage', {
                 'chat_id': user_id,
-                'text': 'Choose channel',
+                'text': 'Select channels',
                 'reply_markup': keyboard
             })
             return
@@ -238,14 +463,60 @@ class Bot:
     async def handle_callback(self, query):
         user_id = query['from']['id']
         data = query['data']
-        if data.startswith('channel:') and user_id in self.pending:
+        if data.startswith('addch:') and user_id in self.pending:
             chat_id = int(data.split(':')[1])
-            self.pending[user_id]['target_chat_id'] = chat_id
-            self.pending[user_id]['await_time'] = True
-            await self.api_request('sendMessage', {
-                'chat_id': user_id,
-                'text': 'Enter time (HH:MM or DD.MM.YYYY HH:MM)'
-            })
+            if 'selected' in self.pending[user_id]:
+                s = self.pending[user_id]['selected']
+                if chat_id in s:
+                    s.remove(chat_id)
+                else:
+                    s.add(chat_id)
+        elif data == 'chdone' and user_id in self.pending:
+            info = self.pending[user_id]
+            if not info.get('selected'):
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Select at least one channel'})
+            else:
+                self.pending[user_id]['await_time'] = True
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': 'Enter time (HH:MM or DD.MM.YYYY HH:MM)'
+                })
+        elif data.startswith('approve:') and self.is_superadmin(user_id):
+            uid = int(data.split(':')[1])
+            if self.approve_user(uid):
+                cur = self.db.execute('SELECT username FROM users WHERE user_id=?', (uid,))
+                row = cur.fetchone()
+                uname = row['username'] if row else None
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': f'{self.format_user(uid, uname)} approved',
+                    'parse_mode': 'Markdown'
+                })
+                await self.api_request('sendMessage', {'chat_id': uid, 'text': 'You are approved'})
+            else:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'User not in pending list'})
+        elif data.startswith('reject:') and self.is_superadmin(user_id):
+            uid = int(data.split(':')[1])
+            if self.reject_user(uid):
+                cur = self.db.execute('SELECT username FROM rejected_users WHERE user_id=?', (uid,))
+                row = cur.fetchone()
+                uname = row['username'] if row else None
+                await self.api_request('sendMessage', {
+                    'chat_id': user_id,
+                    'text': f'{self.format_user(uid, uname)} rejected',
+                    'parse_mode': 'Markdown'
+                })
+                await self.api_request('sendMessage', {'chat_id': uid, 'text': 'Your registration was rejected'})
+            else:
+                await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'User not in pending list'})
+        elif data.startswith('cancel:') and self.is_authorized(user_id):
+            sid = int(data.split(':')[1])
+            self.remove_schedule(sid)
+            await self.api_request('sendMessage', {'chat_id': user_id, 'text': f'Schedule {sid} cancelled'})
+        elif data.startswith('resch:') and self.is_authorized(user_id):
+            sid = int(data.split(':')[1])
+            self.pending[user_id] = {'reschedule_id': sid, 'await_time': True}
+            await self.api_request('sendMessage', {'chat_id': user_id, 'text': 'Enter new time'})
         await self.api_request('answerCallbackQuery', {'callback_query_id': query['id']})
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,15 +2,230 @@ import os
 import sys
 import pytest
 from aiohttp import web
+from datetime import datetime, timedelta
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-from main import create_app
+from main import create_app, Bot
 
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy")
 
 @pytest.mark.asyncio
 async def test_startup_cleanup():
     app = create_app()
+
+    async def dummy(method, data=None):
+        return {"ok": True}
+
+    app['bot'].api_request = dummy  # type: ignore
+
     runner = web.AppRunner(app)
     await runner.setup()
     await runner.cleanup()
+
+@pytest.mark.asyncio
+async def test_registration_queue(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    row = bot.get_user(1)
+    assert row and row["is_superadmin"] == 1
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 2}}})
+    assert bot.is_pending(2)
+
+    # reject user 2 and ensure they cannot re-register
+    bot.reject_user(2)
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 2}}})
+    assert bot.is_rejected(2)
+    assert not bot.is_pending(2)
+    assert calls[-1][0] == 'sendMessage'
+    assert calls[-1][1]['text'] == 'Access denied by administrator'
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_superadmin_user_management(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 2}}})
+    await bot.handle_update({"message": {"text": "/pending", "from": {"id": 1}}})
+    assert bot.is_pending(2)
+    pending_msg = calls[-1]
+    assert pending_msg[0] == 'sendMessage'
+    assert pending_msg[1]['reply_markup']['inline_keyboard'][0][0]['callback_data'] == 'approve:2'
+    assert 'tg://user?id=2' in pending_msg[1]['text']
+    assert pending_msg[1]['parse_mode'] == 'Markdown'
+
+    await bot.handle_update({"message": {"text": "/approve 2", "from": {"id": 1}}})
+    assert bot.get_user(2)
+    assert not bot.is_pending(2)
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 3}}})
+    await bot.handle_update({"message": {"text": "/reject 3", "from": {"id": 1}}})
+    assert not bot.is_pending(3)
+    assert not bot.get_user(3)
+
+    await bot.handle_update({"message": {"text": "/remove_user 2", "from": {"id": 1}}})
+    assert not bot.get_user(2)
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_list_users_links(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    await bot.start()
+
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1, "username": "admin"}}})
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 2, "username": "user"}}})
+    bot.approve_user(2)
+
+    await bot.handle_update({"message": {"text": "/list_users", "from": {"id": 1}}})
+    msg = calls[-1][1]
+    assert msg['parse_mode'] == 'Markdown'
+    assert 'tg://user?id=1' in msg['text']
+    assert 'tg://user?id=2' in msg['text']
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_channel_tracking(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    await bot.start()
+
+    # register superadmin
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+
+    # bot added to channel
+    await bot.handle_update({
+        "my_chat_member": {
+            "chat": {"id": -100, "title": "Chan"},
+            "new_chat_member": {"status": "administrator"}
+        }
+    })
+    cur = bot.db.execute('SELECT title FROM channels WHERE chat_id=?', (-100,))
+    row = cur.fetchone()
+    assert row and row["title"] == "Chan"
+
+    await bot.handle_update({"message": {"text": "/channels", "from": {"id": 1}}})
+    assert calls[-1][1]["text"] == "Chan (-100)"
+
+    # non-admin cannot list channels
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 2}}})
+    await bot.handle_update({"message": {"text": "/channels", "from": {"id": 2}}})
+    assert calls[-1][1]["text"] == "Not authorized"
+
+    # bot removed from channel
+    await bot.handle_update({
+        "my_chat_member": {
+            "chat": {"id": -100, "title": "Chan"},
+            "new_chat_member": {"status": "left"}
+        }
+    })
+    cur = bot.db.execute('SELECT * FROM channels WHERE chat_id=?', (-100,))
+    assert cur.fetchone() is None
+
+    await bot.close()
+
+
+@pytest.mark.asyncio
+async def test_schedule_flow(tmp_path):
+    bot = Bot("dummy", str(tmp_path / "db.sqlite"))
+
+    calls = []
+
+    async def dummy(method, data=None):
+        calls.append((method, data))
+        return {"ok": True}
+
+    bot.api_request = dummy  # type: ignore
+    await bot.start()
+
+    # register superadmin
+    await bot.handle_update({"message": {"text": "/start", "from": {"id": 1}}})
+
+    # bot added to two channels
+    await bot.handle_update({
+        "my_chat_member": {
+            "chat": {"id": -100, "title": "Chan1"},
+            "new_chat_member": {"status": "administrator"}
+        }
+    })
+    await bot.handle_update({
+        "my_chat_member": {
+            "chat": {"id": -101, "title": "Chan2"},
+            "new_chat_member": {"status": "administrator"}
+        }
+    })
+
+    # forward a message to schedule
+    await bot.handle_update({
+        "message": {
+            "forward_from_chat": {"id": 500},
+            "forward_from_message_id": 7,
+            "from": {"id": 1}
+        }
+    })
+    assert calls[-1][1]["reply_markup"]["inline_keyboard"][-1][0]["callback_data"] == "chdone"
+
+    # select channels and finish
+    await bot.handle_update({"callback_query": {"from": {"id": 1}, "data": "addch:-100", "id": "q"}})
+    await bot.handle_update({"callback_query": {"from": {"id": 1}, "data": "addch:-101", "id": "q"}})
+    await bot.handle_update({"callback_query": {"from": {"id": 1}, "data": "chdone", "id": "q"}})
+
+    time_str = (datetime.utcnow() + timedelta(minutes=5)).strftime("%H:%M")
+    await bot.handle_update({"message": {"text": time_str, "from": {"id": 1}}})
+
+    cur = bot.db.execute("SELECT target_chat_id FROM schedule ORDER BY target_chat_id")
+    rows = [r["target_chat_id"] for r in cur.fetchall()]
+    assert rows == [-101, -100] or rows == [-100, -101]
+
+    # list schedules
+    await bot.handle_update({"message": {"text": "/scheduled", "from": {"id": 1}}})
+    assert "cancel" in calls[-1][1]["reply_markup"]["inline_keyboard"][0][0]["callback_data"]
+
+    # cancel first schedule
+    cur = bot.db.execute("SELECT id FROM schedule ORDER BY id")
+    sid = cur.fetchone()["id"]
+    await bot.handle_update({"callback_query": {"from": {"id": 1}, "data": f"cancel:{sid}", "id": "c"}})
+    cur = bot.db.execute("SELECT * FROM schedule WHERE id=?", (sid,))
+    assert cur.fetchone() is None
+
+    await bot.close()


### PR DESCRIPTION
## Summary
- show clickable usernames in user lists
- persist usernames in database tables
- update approval and rejection flows to include usernames
- document improved US-3
- test user lists with links

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859b69c50648332bc88f5570d545ebb